### PR TITLE
Porting to use CMake on OS X

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,29 @@
+CMAKE_MINIMUM_REQUIRED ( VERSION 2.8 )
+
+PROJECT ( houio )
+
+INCLUDE_DIRECTORIES ( include )
+
+ADD_LIBRARY ( houio STATIC
+  src/Attribute.cpp
+  src/Field.cpp
+  src/math/Color.cpp
+  src/math/Math.cpp
+  src/json.cpp
+  src/HouGeoAdapter.cpp
+  src/HouGeo.cpp
+  src/HouGeoIO.cpp
+  src/Geometry.cpp
+  )
+
+INSTALL ( TARGETS
+  houio
+  DESTINATION
+  lib
+  )
+
+INSTALL ( DIRECTORY
+  include
+  DESTINATION
+  .
+  )

--- a/include/houio/math/Math.h
+++ b/include/houio/math/Math.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <math.h>
+#include <cmath>
 
 #define MATH_PIf 3.14159265f
 #define MATH_PI 3.14159265


### PR DESCRIPTION
The installation of the include files are interim, when houio merge with hougeo, a review of the combine installation is required. For now this will suffice.
