### PR TITLE
Fix loading of large datasets

### DIFF
--- a/include/houio/Attribute.h
+++ b/include/houio/Attribute.h
@@ -55,7 +55,7 @@ namespace houio
 			m_isDirty = true;
 		}
 
-		void resize( int numElements )
+		void resize( size_t numElements )
 		{
 			m_data.resize( numElements*numComponents()*elementComponentSize() );
 			m_numElements = numElements;
@@ -100,7 +100,7 @@ namespace houio
 		char              m_componentSize; // size in memory of a component of an element in byte
 		ComponentType     m_componentType;
 		char              m_numComponents; // number of components per element
-		int                 m_numElements;
+		size_t              m_numElements;
 
 		//
 		// static creators

--- a/include/houio/json.h
+++ b/include/houio/json.h
@@ -663,7 +663,7 @@ namespace houio
 			t_dest &dest;
 			VariantConverter( t_dest &_dest ) : dest(_dest){}
 
-			void operator()(std::string x)
+			void operator()(std::string /*x*/)
 			{
 				dest = false;
 			}
@@ -682,7 +682,7 @@ namespace houio
 			t_dest &dest;
 			VariantConverter( t_dest &_dest ) : dest(_dest){}
 
-			void operator()(std::string x)
+			void operator()(std::string /*x*/)
 			{
 				//dest = false;
 			}
@@ -701,7 +701,7 @@ namespace houio
 			t_dest &dest;
 			VariantConverter( t_dest &_dest ) : dest(_dest){}
 
-			void operator()(std::string x)
+			void operator()(std::string /*x*/)
 			{
 				//dest = false;
 			}
@@ -720,7 +720,7 @@ namespace houio
 			t_dest &dest;
 			VariantConverter( t_dest &_dest ) : dest(_dest){}
 
-			void operator()(std::string x)
+			void operator()(std::string /*x*/)
 			{
 				//dest = false;
 			}
@@ -757,7 +757,7 @@ namespace houio
 		template<typename T>
 		const T Value::as()const
 		{
-			T dest;
+			T dest = T();
 			VariantConverter<T> conv(dest);
 			ttl::var::apply_visitor(conv, m_value);
 			return dest;

--- a/src/Attribute.cpp
+++ b/src/Attribute.cpp
@@ -9,10 +9,10 @@
 namespace houio
 {
 	Attribute::Attribute( char numComponents, ComponentType componentType ) :
-		m_numElements(0),
+		m_componentType(componentType),
 		m_numComponents(numComponents),
-		m_isDirty(true),
-		m_componentType(componentType)
+		m_numElements(0),
+		m_isDirty(true)
 	{
 		switch(componentType)
 		{

--- a/src/Geometry.cpp
+++ b/src/Geometry.cpp
@@ -13,8 +13,8 @@ namespace houio
 {
 	Geometry::Geometry( PrimitiveType pt ) :
 		m_primitiveType(pt),
-		m_numPrimitives(0),
-		m_indexBufferIsDirty(true)
+		m_indexBufferIsDirty(true),
+		m_numPrimitives(0)
 	{
 		switch( pt )
 		{
@@ -493,7 +493,6 @@ namespace houio
 		}else
 		if( primType == Geometry::LINE )
 		{
-			int numVertices = positions->numElements();
 			for( int j=0; j<vSubdivisions-3;++j )
 			{
 				int offset = j*(uSubdivisions);

--- a/src/HouGeo.cpp
+++ b/src/HouGeo.cpp
@@ -439,7 +439,7 @@ namespace houio
 
 			int attrComponentSize = AttributeAdapter::storageSize( attrStorage );
 			int dstTupleSize = attrTupleSize;
-			int dstComponentSize = attrComponentSize;
+			size_t dstComponentSize = attrComponentSize;
 			//attr->data.resize( elementCount*dstTupleSize*dstComponentSize );
 
 			if( attrData->hasKey("values") )
@@ -510,7 +510,7 @@ namespace houio
 					while( elementsRemaining>0 )
 					{
 						int pageStartElement = pageIndex*elementsPerPage;
-						int numElements = std::min( elementsRemaining, elementsPerPage );
+						size_t numElements = std::min( elementsRemaining, elementsPerPage );
 
 						// process each pack
 						int packIndex = 0;
@@ -518,7 +518,7 @@ namespace houio
 						for( std::vector<ubyte>::iterator it = attrPacking.begin(); it != attrPacking.end();++it, ++packIndex )
 						{
 							ubyte pack = *it;
-							int maxPack = std::min( (int)pack, std::max(0, dstTupleSize-startComponentIndex) );
+							size_t maxPack = std::min( (int)pack, std::max(0, dstTupleSize-startComponentIndex) );
 
 							if( maxPack == 0 )
 								break;
@@ -530,10 +530,10 @@ namespace houio
 
 							// if pack is constant only the first element is given, this is the reference
 							// find element index where the new page starts
-							int elementIndex = pageStartIndex;
+							size_t elementIndex = pageStartIndex;
 
 							// now iterate over all elements of current page and get values from current pack
-							for( int i=0;i<numElements;++i )
+							for( size_t i=0;i<numElements;++i )
 							{
 								// we update elementIndex only if pack is varying within current page
 								// otherwise we will just keep pointing to the reference element
@@ -548,10 +548,10 @@ namespace houio
 									//qDebug() << "pack " << pack;
 
 								// get global element index for writing into our dense array
-								int destElementIndex = (pageStartElement+i)*dstTupleSize;
+								size_t destElementIndex = (pageStartElement+i)*dstTupleSize;
 
 								// for each component of current pack
-								for( int component=0;component<maxPack;++component )
+								for( size_t component=0;component<maxPack;++component )
 									// get component value from current rawpagedata
 									// and copy that component to the location of that component in dense array
 									// TODO: uniform arrays!

--- a/src/HouGeo.cpp
+++ b/src/HouGeo.cpp
@@ -191,12 +191,12 @@ namespace houio
 	}
 
 	HouGeo::HouAttribute::HouAttribute( const std::string &name, Attribute::Ptr attr ) : AttributeAdapter(),
-		m_attr(attr),
 		m_name(name),
-		m_type(HouGeoAdapter::AttributeAdapter::ATTR_TYPE_NUMERIC),
-		m_storage(ATTR_STORAGE_FPREAL32),
 		tupleSize(attr->numComponents()),
-		numElements(attr->numElements())
+		m_storage(ATTR_STORAGE_FPREAL32),
+		m_type(HouGeoAdapter::AttributeAdapter::ATTR_TYPE_NUMERIC),
+		numElements(attr->numElements()),
+		m_attr(attr)
 	{
 		switch( m_attr->elementComponentType() )
 		{
@@ -696,6 +696,10 @@ namespace houio
 						//p = *(math::V3d *)&m_pointAttributes.find("P")->second->data[ v*pAttr->tupleSize*sizeof(double) ];
 						p = m_pointAttributes.find("P")->second->m_attr->get<math::V3d>( v );
 					}break;
+				case AttributeAdapter::ATTR_STORAGE_INVALID:
+				case AttributeAdapter::ATTR_STORAGE_INT32:
+				default:
+					break;
 				}
 			}
 			math::Matrix44d houLocalToWorldTranslation = math::Matrix44d::TranslationMatrix(p);

--- a/src/HouGeoAdapter.cpp
+++ b/src/HouGeoAdapter.cpp
@@ -92,7 +92,7 @@ namespace houio
 		case ATTR_STORAGE_FPREAL32:return sizeof(float);break;
 		case ATTR_STORAGE_FPREAL64:return sizeof(double);break;
 		case ATTR_STORAGE_INT32:return sizeof(int);break;
-		default: 0;break;
+		default:break;
 		};
 		return 0;
 	}

--- a/src/HouGeoIO.cpp
+++ b/src/HouGeoIO.cpp
@@ -257,6 +257,7 @@ namespace houio
 			{
 				int point = vertex_ptr[i];
 				if( !pointsToSplit[point] )
+				{
 					if( firstVertex[point] >=0 )
 					{
 						// compare
@@ -269,6 +270,7 @@ namespace houio
 							}
 					}else
 						firstVertex[point] = i;
+				}
 			}
 
 			int vertexIndex = 0;
@@ -379,7 +381,7 @@ namespace houio
 
 			size_t numIndices = geo->m_indexBuffer.size();
 			top->indexBuffer.resize(numIndices);
-			for( int i=0;i<numIndices;++i )
+			for( size_t i=0;i<numIndices;++i )
 				top->indexBuffer[i] = geo->m_indexBuffer[i];
 
 			houGeo->setTopology(top);

--- a/src/math/Math.cpp
+++ b/src/math/Math.cpp
@@ -445,8 +445,6 @@ namespace math
 
 	void evalCatmullRom( const float *keyPos, const float *keyT, int num, int dim, float t, float *v )
 	{
-		const int size = dim + 1;
-
 		if( t<0.0f )t=0.0f;
 		if( t>1.0f )t=1.0f;
 
@@ -477,8 +475,6 @@ namespace math
 
 	void evalLinear( const float *keyPos, const float *keyT, int num, int dim, float t, float *v )
 	{
-		const int size = dim + 1;
-
 		if( t<0.0f )t=0.0f;
 		if( t>1.0f )t=1.0f;
 


### PR DESCRIPTION
Hello,
This PR avoids an integer overflow when loading large datasets (resulting in a std::bad_alloc exception, see issue #5) and removes some compiler warnings.