### PR TITLE
Add: handle string attributes

### DIFF
--- a/include/houio/HouGeo.h
+++ b/include/houio/HouGeo.h
@@ -44,8 +44,9 @@ namespace houio
 			Storage                               m_storage;
 			Type                                  m_type;
 			//std::vector<char>                     data;
-			std::vector<std::string>              strings; // used in case of type==string
-			int                                   numElements;
+			std::vector<std::string>            strings; 		// used in case of type==string
+			std::vector<int>                    stringsIdxs;    // used in case of type==string
+			int                                 numElements;
 
 			Attribute::Ptr                        m_attr; // primitives::Attribute
 		};

--- a/include/houio/HouGeo.h
+++ b/include/houio/HouGeo.h
@@ -34,6 +34,13 @@ namespace houio
 			virtual void                          getPacking( std::vector<int> &packing )const;
 			virtual int                           getNumElements()const;
 			virtual std::string                   getString( int index )const;
+			virtual std::string                   getUniqueString( int index )const;
+			virtual int                           getStringIndex( int index )const;
+			virtual std::vector<std::string>      getUniqueStrings()const;
+			virtual std::vector<int>              getStringIndices()const;
+
+
+
 			virtual RawPointer::Ptr               getRawPointer();
 
 			//int                                   addV4f(math::V4f value);

--- a/include/houio/HouGeoAdapter.h
+++ b/include/houio/HouGeoAdapter.h
@@ -57,6 +57,10 @@ namespace houio
 			virtual int                      getNumElements()const;
 			virtual RawPointer::Ptr          getRawPointer();
 			virtual std::string              getString( int index )const=0;
+			virtual std::string              getUniqueString( int index )const=0;
+			virtual int                      getStringIndex( int index )const=0;
+			virtual std::vector<std::string> getUniqueStrings()const=0;
+			virtual std::vector<int>         getStringIndices()const=0;
 			static Type                      type( const std::string &typeName );
 			static Storage                   storage( const std::string &storageName );
 			static int                       storageSize( Storage storage );

--- a/src/HouGeo.cpp
+++ b/src/HouGeo.cpp
@@ -280,12 +280,17 @@ namespace houio
 		m_type = ATTR_TYPE_STRING;
 		//attr->storage = attrStorage;
 		tupleSize = 1;
+
+		// TODO : handle indices
 		return numElements++;
 	}
 
 	std::string HouGeo::HouAttribute::getString( int index )const
 	{
-		return strings[index];
+		if(stringsIdxs.size() < index)
+			throw std::runtime_error("HouGeo::getString Index is out of stringsIdx range.");
+		int string_index = stringsIdxs[index];
+		return strings[string_index];
 	}
 
 
@@ -583,6 +588,10 @@ namespace houio
 		}else
 		if( attrType == AttributeAdapter::ATTR_TYPE_STRING )
 		{
+			attr->m_name = attrName;
+			attr->m_type = attrType;
+			attr->tupleSize = 1;
+
 			if( attrData->hasKey("strings") )
 			{
 				json::ArrayPtr stringsArray = attrData->getArray("strings");
@@ -591,14 +600,21 @@ namespace houio
 				{
 					std::string string = stringsArray->get<std::string>( i );
 					attr->strings.push_back(string);
-					//qDebug() << QString::fromStdString(string);
 				}
 				attr->numElements = numElements;
+			}
 
-				attr->m_name = attrName;
-				attr->m_type = attrType;
-				//attr->storage = attrStorage;
-				attr->tupleSize = 1;
+			if( attrData->hasKey("indices") )
+			{
+				json::ObjectPtr indicesObject = toObject(attrData->getArray("indices"));
+				json::ArrayPtr indices = indicesObject->getArray("rawpagedata");
+				int numElements = indices->size();
+				for( int i=0;i<numElements;++i )
+				{
+					int index = indices->get<int>(i);
+					attr->stringsIdxs.push_back(index);
+				}
+				attr->numElements = numElements;
 			}
 		}
 
@@ -886,7 +902,7 @@ namespace houio
 	{
 		return field->sample(i, j, k);
 	}
-	
+
 	math::Vec3i HouGeo::HouVolume::getResolution()const
 	{
 		return field->getResolution();
@@ -994,7 +1010,7 @@ namespace houio
 
 
 
-	
+
 
 
 

--- a/src/HouGeo.cpp
+++ b/src/HouGeo.cpp
@@ -419,13 +419,12 @@ namespace houio
 			json::ArrayPtr entries = o->getArray("sharedprimitivedata");
 
 			int numEntries = (int)entries->size()/2;
+			int index = 0;
 			for( int i=0;i<numEntries;++i )
 			{
-				int index = i*2;
-				std::string type_questionmark = entries->get<std::string>(index);
+				index = i*2;
 				json::ArrayPtr entry = entries->getArray(index+1);
 
-				std::string type2_questionmark = entry->get<std::string>(0);
 				std::string id = entry->get<std::string>(1);
 				json::ArrayPtr data = entry->getArray(2);
 
@@ -620,10 +619,11 @@ namespace houio
 			{
 				json::ArrayPtr stringsArray = attrData->getArray("strings");
 				int numElements = stringsArray->size();
+				std::string stringValue = "";
 				for( int i=0;i<numElements;++i )
 				{
-					std::string string = stringsArray->get<std::string>( i );
-					attr->strings.push_back(string);
+					stringValue = stringsArray->get<std::string>( i );
+					attr->strings.push_back(stringValue);
 				}
 				attr->numElements = numElements;
 			}
@@ -633,9 +633,10 @@ namespace houio
 				json::ObjectPtr indicesObject = toObject(attrData->getArray("indices"));
 				json::ArrayPtr indices = indicesObject->getArray("rawpagedata");
 				int numElements = indices->size();
+				int index = 0;
 				for( int i=0;i<numElements;++i )
 				{
-					int index = indices->get<int>(i);
+					index = indices->get<int>(i);
 					attr->stringsIdxs.push_back(index);
 				}
 				attr->numElements = numElements;

--- a/src/HouGeo.cpp
+++ b/src/HouGeo.cpp
@@ -285,12 +285,36 @@ namespace houio
 		return numElements++;
 	}
 
+	std::string HouGeo::HouAttribute::getUniqueString( int index )const
+	{
+		if(strings.size() < index)
+			throw std::runtime_error("HouGeo::getString Index is out of strings range.");
+		return strings[index];
+	}
+
 	std::string HouGeo::HouAttribute::getString( int index )const
 	{
 		if(stringsIdxs.size() < index)
-			throw std::runtime_error("HouGeo::getString Index is out of stringsIdx range.");
-		int string_index = stringsIdxs[index];
+			throw std::runtime_error("HouGeo::getString Index is out of strings range.");
+		const int string_index = stringsIdxs[index];
 		return strings[string_index];
+	}
+
+	int HouGeo::HouAttribute::getStringIndex( int index )const
+	{
+		if(stringsIdxs.size() < index)
+			throw std::runtime_error("HouGeo::getStringIndex Index is out of stringsIdx range.");
+		return stringsIdxs[index];
+	}
+
+	std::vector<std::string> HouGeo::HouAttribute::getUniqueStrings()const
+	{
+		return strings;
+	}
+
+	std::vector<int> HouGeo::HouAttribute::getStringIndices()const
+	{
+		return stringsIdxs;
 	}
 
 


### PR DESCRIPTION
To resolve this issue : #7 

String attributes are stored in json file as follow :
[
    "size",1,
    "storage","int32",
    "strings",["/pCube1/pCubeShape1","/pSphere1/pSphereShape1"],
    "indices",[
	"size",1,
	"storage","int32",
	"arrays",[[0,1,0,1,0,1,0,1,0,1]]
    ]
]

Store "arrays" in new 'stringIdxs' attribute